### PR TITLE
Prefer viewport buffer in jump-to-buffer

### DIFF
--- a/agent-shell-attention.el
+++ b/agent-shell-attention.el
@@ -47,6 +47,7 @@
 (declare-function agent-shell--send-command "agent-shell")
 (declare-function dired "dired" (&optional dirname switches))
 (declare-function acp-send-request "acp")
+(declare-function agent-shell-viewport--buffer "agent-shell-viewport")
 
 (defgroup agent-shell-attention nil
   "Mode-line tally and minibuffer notifications for agent-shell buffers."
@@ -666,11 +667,20 @@ CANDIDATES is an alist of (DISPLAY . (BUFFER . STATUS))."
         `((group-function . ,group)))))))
 
 (defun agent-shell-attention--jump-to-buffer (buffer)
-  "Switch to BUFFER, clearing pending state when appropriate."
+  "Switch to BUFFER, clearing pending state when appropriate.
+When `agent-shell-prefer-viewport-interaction' is non-nil and BUFFER
+has an existing viewport buffer, switch to the viewport instead."
   (when (buffer-live-p buffer)
     (unless (agent-shell-attention--permission-pending-p buffer)
       (agent-shell-attention--clear-buffer buffer))
-    (pop-to-buffer buffer agent-shell-attention-display-buffer-action)))
+    (let ((target (if (and (boundp 'agent-shell-prefer-viewport-interaction)
+                           agent-shell-prefer-viewport-interaction
+                           (fboundp 'agent-shell-viewport--buffer))
+                      (or (agent-shell-viewport--buffer
+                           :shell-buffer buffer :existing-only t)
+                          buffer)
+                    buffer)))
+      (pop-to-buffer target agent-shell-attention-display-buffer-action))))
 
 (defun agent-shell-attention--build-menu (entries)
   "Create popup menu for ENTRIES.


### PR DESCRIPTION
Fixes #3.

## Summary

- When `agent-shell-prefer-viewport-interaction` is non-nil and the target shell buffer already has a viewport buffer, `agent-shell-attention--jump-to-buffer` now switches to the viewport instead of the raw shell buffer.
- This applies to all jump entry points: the menu, dashboard, and `agent-shell-attention-jump`.
- The change is fully guarded behind `boundp`/`fboundp` checks so it is safe when `agent-shell-viewport` is not loaded.

## Details

`agent-shell-attention--jump-to-buffer` is the single function through which every attention-jump flows. By resolving the viewport buffer here (when the user preference is set and a viewport already exists), all callers automatically respect the viewport interaction preference without any additional changes.

A `declare-function` for `agent-shell-viewport--buffer` is added near the existing forward declarations to satisfy the byte-compiler.